### PR TITLE
Remove test job from GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,19 +25,3 @@ jobs:
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: "9.9"
-      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
-        with:
-          node-version-file: "package.json"
-          cache: "pnpm"
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm playwright install chromium
-      - run: pnpm test
-        env:
-          CI: true


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow configuration file `.github/workflows/main.yml`. The change removes the `test` job, which was responsible for running the tests on the `ubuntu-latest` runner.

Changes in `.github/workflows/main.yml`:

* Removed the `test` job, including all its steps, which involved checking out the repository, setting up `pnpm` and Node.js, installing dependencies, installing Playwright, and running tests.